### PR TITLE
feat: add admin API key validation to reset and revalidate routes

### DIFF
--- a/.github/workflows/job-articles.yml
+++ b/.github/workflows/job-articles.yml
@@ -16,5 +16,5 @@ jobs:
     - run: curl -XPOST https://sentiment-guardian.vercel.app/api/articles -d '{"adminApiKey":"${{ secrets.ADMIN_API_KEY }}"}'
     - run: curl -XPOST https://sentiment-guardian.vercel.app/api/sentiment -d '{"adminApiKey":"${{ secrets.ADMIN_API_KEY }}"}'
     - run: echo "Done!"
-    - run: curl -XPOST https://sentiment-guardian.vercel.app/api/revalidate
+    - run: curl -XPOST https://sentiment-guardian.vercel.app/api/revalidate -d '{"adminApiKey":"${{ secrets.ADMIN_API_KEY }}"}'
     - run: echo "Cache revalidated!"

--- a/app/api/reset/route.js
+++ b/app/api/reset/route.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
 import { Redis } from '@upstash/redis';
+import { timingSafeEqual } from 'crypto';
 
 export const revalidate = 0;
 
@@ -7,8 +7,6 @@ const redis = new Redis({
     token: process.env.UPSTASH_REDIS_REST_TOKEN,
     url: process.env.UPSTASH_REDIS_REST_URL,
 });
-
-import { timingSafeEqual } from 'crypto';
 
 export async function POST(req) {
     const { adminApiKey } = await req.json();
@@ -18,7 +16,7 @@ export async function POST(req) {
         !timingSafeEqual(Buffer.from(adminApiKey), Buffer.from(expectedKey))) {
         return new Response('Unauthorized', { status: 403 });
     }
-}
+
     // flushall
     await redis.flushall();
     // TODO: Reset vercel cache by tag.

--- a/app/api/reset/route.js
+++ b/app/api/reset/route.js
@@ -8,12 +8,17 @@ const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL,
 });
 
-export async function GET(req) {
-    const { adminApiKey } = await req.json();
+import { timingSafeEqual } from 'crypto';
 
-    if (adminApiKey !== process.env.ADMIN_API_KEY) {
+export async function POST(req) {
+    const { adminApiKey } = await req.json();
+    const expectedKey = process.env.ADMIN_API_KEY;
+    
+    if (!adminApiKey || !expectedKey || 
+        !timingSafeEqual(Buffer.from(adminApiKey), Buffer.from(expectedKey))) {
         return new Response('Unauthorized', { status: 403 });
     }
+}
     // flushall
     await redis.flushall();
     // TODO: Reset vercel cache by tag.

--- a/app/api/reset/route.js
+++ b/app/api/reset/route.js
@@ -8,12 +8,15 @@ const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL,
 });
 
-export async function GET() {
+export async function GET(req) {
+    const { adminApiKey } = await req.json();
 
+    if (adminApiKey !== process.env.ADMIN_API_KEY) {
+        return new Response('Unauthorized', { status: 403 });
+    }
     // flushall
     await redis.flushall();
     // TODO: Reset vercel cache by tag.
 
-    // Select latest 100 articles from Redis.
     return new Response('Redis flushed', { status: 200 });
 }

--- a/app/api/revalidate/route.js
+++ b/app/api/revalidate/route.js
@@ -2,8 +2,12 @@
 // import { NextResponse } from 'next/server';
 import { revalidateTag } from 'next/cache';
 
-export async function POST() {
+export async function POST(req) {
+    const { adminApiKey } = await req.json();
 
+    if (adminApiKey !== process.env.ADMIN_API_KEY) {
+        return new Response('Unauthorized', { status: 403 });
+    }
     console.log('Revalidating Tags');
     revalidateTag('article:guardian');
     console.log('Revalidated article:guardian');


### PR DESCRIPTION
This pull request includes several security improvements by adding authentication checks for API endpoints and modifying the workflow to include the `adminApiKey` in the revalidation request.

Security improvements:

* [`.github/workflows/job-articles.yml`](diffhunk://#diff-aee5eb133667c94d432667545354d3e74b6d8d81c983bcec657bafbff908cfd2L19-R19): Modified the revalidation request to include the `adminApiKey` in the payload.
* [`app/api/reset/route.js`](diffhunk://#diff-d0faddc594c8fe611da61ff0d407a1f8f60758e5b28d29db38b8500d0ddd902cL11-L17): Added authentication check by verifying the `adminApiKey` from the request body before allowing the Redis flush operation.
* [`app/api/revalidate/route.js`](diffhunk://#diff-cb4e502691b35a7fc014f9128daef155e2f1a0c892f38ff3caae93e6c2c6b6ecL5-R10): Added authentication check by verifying the `adminApiKey` from the request body before allowing the revalidation of tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API endpoints to verify administrative credentials, ensuring only authorized requests can execute sensitive operations.
- **Bug Fixes**
	- Updated the deployment workflow so that cache revalidation now securely includes necessary authentication details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->