### PR TITLE
feat: add MCP server configuration

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,47 @@
+{
+	"inputs": [
+		// The "inputs" section defines the inputs required for the MCP server configuration. 
+		{
+			"type": "promptString",
+			"id": "upstashRestUrl",
+			"description": "Enter the Upstash REST URL",
+			"password": false
+		},
+		{
+			"type": "promptString",
+			"id": "upstashRestToken",
+			"description": "Enter the Upstash REST Token",
+			"password": true
+		},
+		{
+			"type": "promptString",
+			"id": "upstashRestEmail",
+			"description": "Enter the Upstash REST Email",
+			"password": false
+		},
+		{
+			"type": "promptString",
+			"id": "upstashRestApiKey",
+			"description": "Enter the Upstash REST API Key",
+			"password": true
+		}
+	],
+	"servers": {
+		// The "servers" section defines the MCP servers you want to use.
+		"upstash": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"@upstash/mcp-server",
+				"run"
+			],
+			"env": {
+				"UPSTASH_REST_URL": "${input:upstashRestUrl}",
+				"UPSTASH_REST_TOKEN": "${input:upstashRestToken}",
+				"UPSTASH_EMAIL": "${input:upstashRestEmail}",
+				"UPSTASH_API_KEY": "${input:upstashRestApiKey}"
+			}
+		}
+	}
+}

--- a/app/api/sentiment/route.js
+++ b/app/api/sentiment/route.js
@@ -31,7 +31,7 @@ async function doAllTheShit() {
         const chatCompletion = await openai.chat.completions.create({
             messages: [{ content: message, role: 'user' }],
             model: MODEL_GPT_SENTIMENT,
-            user: 'The sentiment of The Guardian'
+            user: 'The Sentiment of The Guardian'
         });
         console.log('chatCompletion for article', article.title, chatCompletion.choices);
         const sentiment = chatCompletion.choices[0].message.content;


### PR DESCRIPTION
This pull request introduces a new configuration file for the MCP server and includes a minor correction to a string in the `doAllTheShit` function. The most important changes are grouped below:

### MCP Server Configuration:

* Added a new `.vscode/mcp.json` file to configure the MCP server. This includes defining input prompts for Upstash credentials (REST URL, Token, Email, and API Key) and setting up the server with environment variables and a command to run the MCP server using `npx`.
